### PR TITLE
Add extractCommentsFromSource function

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@babel/preset-env": "^7.20.2",
     "@babel/preset-typescript": "^7.21.0",
     "@jest/globals": "^29.4.3",
+    "@types/common-tags": "^1.8.1",
     "@types/jest": "^29.4.0",
     "@typescript-eslint/eslint-plugin": "^5.53.0",
     "@typescript-eslint/parser": "^5.53.0",
@@ -41,5 +42,9 @@
     "prettier": "^2.8.4",
     "ts-jest": "^29.0.5",
     "typescript": "^4.9.5"
+  },
+  "dependencies": {
+    "@babel/parser": "^7.21.2",
+    "common-tags": "^1.8.2"
   }
 }

--- a/src/__tests__/extractCommentsFromSource.test.ts
+++ b/src/__tests__/extractCommentsFromSource.test.ts
@@ -12,6 +12,9 @@ test("basic single line comments", async () => {
   `
 
   expect(await extractCommentsFromSource(exampleCode)).toEqual([
-    { value: " TODO This needs some work" },
+    {
+      value: " TODO This needs some work",
+      loc: { start: { column: 2, line: 4, index: 50 }, end: { column: 30, line: 4, index: 78 } },
+    },
   ])
 })

--- a/src/__tests__/extractCommentsFromSource.test.ts
+++ b/src/__tests__/extractCommentsFromSource.test.ts
@@ -1,0 +1,17 @@
+import { stripIndent } from "common-tags"
+import { extractCommentsFromSource } from "../extractCommentsFromSource"
+
+test("basic single line comments", async () => {
+  const exampleCode = stripIndent`
+    import foo from 'bar';
+
+    function myFunction() {
+      // TODO This needs some work
+      return foo();
+    }
+  `
+
+  expect(await extractCommentsFromSource(exampleCode)).toEqual([
+    { value: " TODO This needs some work" },
+  ])
+})

--- a/src/__tests__/extractCommentsFromSource.test.ts
+++ b/src/__tests__/extractCommentsFromSource.test.ts
@@ -1,20 +1,79 @@
 import { stripIndent } from "common-tags"
 import { extractCommentsFromSource } from "../extractCommentsFromSource"
 
-test("basic single line comments", async () => {
-  const exampleCode = stripIndent`
-    import foo from 'bar';
+describe("CommentBlock", () => {
+  // CommentBlock is pretty easy since Babel already takes care of multiple lines.
+  test("basic comments", async () => {
+    const exampleCode = stripIndent`
+      import foo from 'bar';
 
-    function myFunction() {
-      // TODO This needs some work
-      return foo();
-    }
-  `
+      /**
+       * A multi-line CommentBlock here.
+       */
+      function myFunction() {
+        /* This is a single line one. */
+        return foo();
+      }
+    `
 
-  expect(await extractCommentsFromSource(exampleCode)).toEqual([
-    {
-      value: " TODO This needs some work",
-      loc: { start: { column: 2, line: 4, index: 50 }, end: { column: 30, line: 4, index: 78 } },
-    },
-  ])
+    expect(await extractCommentsFromSource(exampleCode)).toEqual([
+      {
+        value: "*\n * A multi-line CommentBlock here.\n ",
+        loc: { start: { column: 0, line: 3, index: 24 }, end: { column: 3, line: 5, index: 66 } },
+      },
+      {
+        value: " This is a single line one. ",
+        loc: { start: { column: 2, line: 7, index: 93 }, end: { column: 34, line: 7, index: 125 } },
+      },
+    ])
+  })
+})
+
+describe("CommentLine", () => {
+  test("basic single line comments", async () => {
+    const exampleCode = stripIndent`
+      import foo from 'bar';
+
+      function myFunction() {
+        // TODO This needs some work
+        return foo();
+      }
+    `
+
+    expect(await extractCommentsFromSource(exampleCode)).toEqual([
+      {
+        value: " TODO This needs some work",
+        loc: { start: { column: 2, line: 4, index: 50 }, end: { column: 30, line: 4, index: 78 } },
+      },
+    ])
+  })
+
+  test("multi-line merging", async () => {
+    const exampleCode = stripIndent`
+      import foo from 'bar';
+
+      function myFunction() {
+        // TODO This should be
+        // multiple lines
+        // long
+
+        // This is another comment but
+        // not a part of the one above.
+      }
+    `
+
+    expect(await extractCommentsFromSource(exampleCode)).toEqual([
+      {
+        value: " TODO This should be\n multiple lines\n long",
+        loc: { start: { column: 2, line: 4, index: 50 }, end: { column: 9, line: 6, index: 102 } },
+      },
+      {
+        value: " This is another comment but\n not a part of the one above.",
+        loc: {
+          start: { column: 2, line: 8, index: 106 },
+          end: { column: 33, line: 9, index: 170 },
+        },
+      },
+    ])
+  })
 })

--- a/src/extractCommentsFromSource.ts
+++ b/src/extractCommentsFromSource.ts
@@ -1,0 +1,20 @@
+import { parse } from "@babel/parser"
+
+interface CommentNode {
+  value: string
+}
+
+export const extractCommentsFromSource = async (sourceText: string): Promise<CommentNode[]> => {
+  const ast = parse(sourceText, {
+    sourceType: "module",
+    plugins: ["typescript", "jsx", "classProperties", "objectRestSpread"],
+  })
+
+  if (!ast.comments) {
+    return []
+  }
+
+  return ast.comments.reduce((acc, comment) => {
+    return [...acc, { value: comment.value }]
+  }, [] as CommentNode[])
+}

--- a/src/extractCommentsFromSource.ts
+++ b/src/extractCommentsFromSource.ts
@@ -2,6 +2,13 @@ import { parse } from "@babel/parser"
 
 interface CommentNode {
   value: string
+  loc?: { start: Location; end: Location }
+}
+
+interface Location {
+  line: number
+  column: number
+  index: number
 }
 
 export const extractCommentsFromSource = async (sourceText: string): Promise<CommentNode[]> => {
@@ -15,6 +22,12 @@ export const extractCommentsFromSource = async (sourceText: string): Promise<Com
   }
 
   return ast.comments.reduce((acc, comment) => {
-    return [...acc, { value: comment.value }]
+    return [
+      ...acc,
+      {
+        value: comment.value,
+        loc: { start: { ...comment.loc!.start }, end: { ...comment.loc!.end } },
+      } as CommentNode,
+    ]
   }, [] as CommentNode[])
 }

--- a/src/extractCommentsFromSource.ts
+++ b/src/extractCommentsFromSource.ts
@@ -22,6 +22,31 @@ export const extractCommentsFromSource = async (sourceText: string): Promise<Com
   }
 
   return ast.comments.reduce((acc, comment) => {
+    // If the comment is a CommentBlock, we don't need to anything special for it.
+    if (comment.type === "CommentBlock") {
+      return [
+        ...acc,
+        {
+          value: comment.value,
+          loc: { start: { ...comment.loc!.start }, end: { ...comment.loc!.end } },
+        } as CommentNode,
+      ]
+    }
+
+    // If the comment is a CommentLine, we need to merge it with the previous comment
+    // if it ended on the line before this one.
+    const previous: CommentNode | undefined = acc[acc.length - 1]
+
+    if (previous && previous.loc!.end.line === comment.loc!.start.line - 1) {
+      return [
+        ...acc.slice(0, -1),
+        {
+          value: `${previous.value}\n${comment.value}`,
+          loc: { start: { ...previous.loc!.start }, end: { ...comment.loc!.end } },
+        } as CommentNode,
+      ]
+    }
+
     return [
       ...acc,
       {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1316,6 +1316,11 @@
   dependencies:
     "@babel/types" "^7.3.0"
 
+"@types/common-tags@^1.8.1":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@types/common-tags/-/common-tags-1.8.1.tgz#a5a49ca5ebbb58e0f8947f3ec98950c8970a68a9"
+  integrity sha512-20R/mDpKSPWdJs5TOpz3e7zqbeCNuMCPhV7Yndk9KU2Rbij2r5W4RzwDPkzC+2lzUqXYu9rFzTktCBnDjHuNQg==
+
 "@types/graceful-fs@^4.1.3":
   version "4.1.6"
   resolved "https://registry.yarnpkg.com/@types/graceful-fs/-/graceful-fs-4.1.6.tgz#e14b2576a1c25026b7f02ede1de3b84c3a1efeae"
@@ -1774,6 +1779,11 @@ color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+
+common-tags@^1.8.2:
+  version "1.8.2"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.2.tgz#94ebb3c076d26032745fd54face7f688ef5ac9c6"
+  integrity sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==
 
 concat-map@0.0.1:
   version "0.0.1"


### PR DESCRIPTION
This function accepts a string of JavaScript/TypeScript source code and returns an array of objects describing the comments in the file.

Most notably, it will merge together contiguous `CommentLine` instances into one object, where normally they are represented in the AST as one comment per line. This will be important for my purposes.
